### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -3,22 +3,22 @@
 #######################################
 
 #######################################
-# Instance				(KEYWORD1)
+# Instance	(KEYWORD1)
 #######################################
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-begin KEYWORD2
-getPressure KEYWORD2
-getTempC  KEYWORD2
-getTempF  KEYWORD2
-getAltitude KEYWORD2
-poll  KEYWORD2
+begin	KEYWORD2
+getPressure	KEYWORD2
+getTempC	KEYWORD2
+getTempF	KEYWORD2
+getAltitude	KEYWORD2
+poll	KEYWORD2
 
 #######################################
-# Constants 			(LITERAL1)
+# Constants	(LITERAL1)
 #######################################
 
 


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords